### PR TITLE
CFEP-18: Remove static libraries from main build

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,11 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
+  - script: |
+         rm -rf /opt/ghc
+         df -h
+    displayName: Manage disk space
+
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |
@@ -27,6 +32,7 @@ jobs:
   - script: |
         export CI=azure
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
         .scripts/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,6 +20,7 @@ jobs:
       export CI=azure
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
       ./.scripts/run_osx_build.sh
     displayName: Run OSX build
     env:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -93,14 +93,16 @@ jobs:
         PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base
-        validate_recipe_outputs "brotli-feedstock"
+        validate_recipe_outputs "%FEEDSTOCK_NAME%"
       displayName: Validate Recipe Outputs
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base
-        upload_package --validate --feedstock-name="brotli-feedstock" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -6,5 +6,3 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2017
-vc:
-- '14'

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,7 @@ steps:
     - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
     - export CI=drone
     - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
     - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
     - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
     - echo "Done building"

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -30,11 +30,12 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --suppress-variables \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "brotli-feedstock"
+validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="brotli-feedstock" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -13,6 +13,10 @@ PROVIDER_DIR="$(basename $THISDIR)"
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"
 
+if [ -z ${FEEDSTOCK_NAME} ]; then
+    export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted
@@ -63,12 +67,14 @@ docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \
-           -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
+           -e FEEDSTOCK_NAME \
+           -e CPU_COUNT \
+           -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \
            $DOCKER_IMAGE \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -47,10 +47,10 @@ set -e
 
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-validate_recipe_outputs "brotli-feedstock"
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
   echo -e "\n\nUploading the packages."
-  upload_package --validate --feedstock-name="brotli-feedstock" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
 script:
   - export CI=travis
   - export GIT_BRANCH="$TRAVIS_BRANCH"
+  - export FEEDSTOCK_NAME=$(basename ${TRAVIS_REPO_SLUG})
 
 
   - if [[ ${PLATFORM} =~ .*linux.* ]]; then ./.scripts/run_docker_build.sh; fi

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://github.com/google/brotli
 
 Package license: MIT
 
-Feedstock license: BSD 3-Clause
+Feedstock license: BSD-3-Clause
 
 Summary: Brotli compression format
 

--- a/recipe/0001-Add-separate-options-to-disable-shared-static-librar.patch
+++ b/recipe/0001-Add-separate-options-to-disable-shared-static-librar.patch
@@ -1,0 +1,202 @@
+From d6d7063ad9851a0bc0e1fc775850554d1dad13be Mon Sep 17 00:00:00 2001
+From: Eugene Kliuchnikov <eustas@google.com>
+Date: Fri, 4 May 2018 15:22:49 +0200
+Subject: [PATCH] Add separate options to disable shared/static libraries
+ build.
+
+---
+ CMakeLists.txt | 114 +++++++++++++++++++++++++++++++------------------
+ 1 file changed, 73 insertions(+), 41 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 99b9258..a9fe097 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,6 +6,9 @@ cmake_minimum_required(VERSION 2.8.6)
+ 
+ project(brotli C)
+ 
++option(BUILD_SHARED_LIBS "Build shared libraries" ON)
++option(BUILD_STATIC_LIBS "Build static libraries" ON)
++
+ # If Brotli is being bundled in another project, we don't want to
+ # install anything.  However, we want to let people override this, so
+ # we'll use the BROTLI_BUNDLED_MODE variable to let them do that; just
+@@ -110,11 +113,19 @@ unset(LOG2_RES)
+ set(BROTLI_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/c/include")
+ mark_as_advanced(BROTLI_INCLUDE_DIRS)
+ 
+-set(BROTLI_LIBRARIES_CORE brotlienc brotlidec brotlicommon)
++if(BUILD_SHARED_LIBS)
++  set(BROTLI_LIBRARIES_CORE brotlienc brotlidec brotlicommon)
++else()
++  set(BROTLI_LIBRARIES_CORE "")
++endif()
+ set(BROTLI_LIBRARIES ${BROTLI_LIBRARIES_CORE} ${LIBM_LIBRARY})
+ mark_as_advanced(BROTLI_LIBRARIES)
+ 
+-set(BROTLI_LIBRARIES_CORE_STATIC brotlienc-static brotlidec-static brotlicommon-static)
++if(BUILD_STATIC_LIBS)
++  set(BROTLI_LIBRARIES_CORE_STATIC brotlienc-static brotlidec-static brotlicommon-static)
++else()
++  set(BROTLI_LIBRARIES_CORE_STATIC "")
++endif()
+ set(BROTLI_LIBRARIES_STATIC ${BROTLI_LIBRARIES_CORE_STATIC} ${LIBM_LIBRARY})
+ mark_as_advanced(BROTLI_LIBRARIES_STATIC)
+ 
+@@ -137,24 +148,28 @@ endfunction()
+ transform_sources_list("scripts/sources.lst" "${CMAKE_CURRENT_BINARY_DIR}/sources.lst.cmake")
+ include("${CMAKE_CURRENT_BINARY_DIR}/sources.lst.cmake")
+ 
+-add_library(brotlicommon SHARED ${BROTLI_COMMON_C})
+-add_library(brotlidec SHARED ${BROTLI_DEC_C})
+-add_library(brotlienc SHARED ${BROTLI_ENC_C})
++if(BUILD_SHARED_LIBS)
++  add_library(brotlicommon SHARED ${BROTLI_COMMON_C})
++  add_library(brotlidec SHARED ${BROTLI_DEC_C})
++  add_library(brotlienc SHARED ${BROTLI_ENC_C})
++endif()
+ 
+-add_library(brotlicommon-static STATIC ${BROTLI_COMMON_C})
+-add_library(brotlidec-static STATIC ${BROTLI_DEC_C})
+-add_library(brotlienc-static STATIC ${BROTLI_ENC_C})
++if(BUILD_STATIC_LIBS)
++  add_library(brotlicommon-static STATIC ${BROTLI_COMMON_C})
++  add_library(brotlidec-static STATIC ${BROTLI_DEC_C})
++  add_library(brotlienc-static STATIC ${BROTLI_ENC_C})
++endif()
+ 
+ # Older CMake versions does not understand INCLUDE_DIRECTORIES property.
+ include_directories(${BROTLI_INCLUDE_DIRS})
+ 
+-foreach(lib brotlicommon brotlidec brotlienc)
++foreach(lib ${BROTLI_LIBRARIES_CORE})
+   target_compile_definitions(${lib} PUBLIC "BROTLI_SHARED_COMPILATION" )
+   string(TOUPPER "${lib}" LIB)
+   set_target_properties (${lib} PROPERTIES DEFINE_SYMBOL "${LIB}_SHARED_COMPILATION" )
+ endforeach()
+ 
+-foreach(lib brotlicommon brotlidec brotlienc brotlicommon-static brotlidec-static brotlienc-static)
++foreach(lib ${BROTLI_LIBRARIES_CORE} ${BROTLI_LIBRARIES_CORE_STATIC})
+   target_link_libraries(${lib} ${LIBM_LIBRARY})
+   set_property(TARGET ${lib} APPEND PROPERTY INCLUDE_DIRECTORIES ${BROTLI_INCLUDE_DIRS})
+   set_target_properties(${lib} PROPERTIES
+@@ -164,11 +179,15 @@ foreach(lib brotlicommon brotlidec brotlienc brotlicommon-static brotlidec-stati
+   set_property(TARGET ${lib} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${BROTLI_INCLUDE_DIRS}")
+ endforeach()
+ 
+-target_link_libraries(brotlidec brotlicommon)
+-target_link_libraries(brotlienc brotlicommon)
++if(BUILD_SHARED_LIBS)
++  target_link_libraries(brotlidec brotlicommon)
++  target_link_libraries(brotlienc brotlicommon)
++endif()
+ 
+-target_link_libraries(brotlidec-static brotlicommon-static)
+-target_link_libraries(brotlienc-static brotlicommon-static)
++if(BUILD_STATIC_LIBS)
++  target_link_libraries(brotlidec-static brotlicommon-static)
++  target_link_libraries(brotlienc-static brotlicommon-static)
++endif()
+ 
+ # For projects stuck on older versions of CMake, this will set the
+ # BROTLI_INCLUDE_DIRS and BROTLI_LIBRARIES variables so they still
+@@ -182,8 +201,13 @@ if(BROTLI_PARENT_DIRECTORY)
+ endif()
+ 
+ # Build the brotli executable
+-add_executable(brotli ${BROTLI_CLI_C})
+-target_link_libraries(brotli ${BROTLI_LIBRARIES_STATIC})
++if(BUILD_STATIC_LIBS)
++  add_executable(brotli ${BROTLI_CLI_C})
++  target_link_libraries(brotli ${BROTLI_LIBRARIES_STATIC})
++else()
++  add_executable(brotli ${BROTLI_CLI_C})
++  target_link_libraries(brotli ${BROTLI_LIBRARIES_CORE})
++endif()
+ 
+ # Installation
+ if(NOT BROTLI_BUNDLED_MODE)
+@@ -192,19 +216,23 @@ if(NOT BROTLI_BUNDLED_MODE)
+     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+   )
+ 
+-  install(
+-    TARGETS ${BROTLI_LIBRARIES_CORE}
+-    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-  )
++  if(BUILD_STATIC_LIBS)
++    install(
++      TARGETS ${BROTLI_LIBRARIES_CORE_STATIC}
++      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++    )
++  endif()
+ 
+-  install(
+-    TARGETS ${BROTLI_LIBRARIES_CORE_STATIC}
+-    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-  )
++  if(BUILD_SHARED_LIBS)
++    install(
++      TARGETS ${BROTLI_LIBRARIES_CORE}
++      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++    )
++  endif()
+ 
+   install(
+     DIRECTORY ${BROTLI_INCLUDE_DIRS}/brotli
+@@ -214,6 +242,10 @@ endif()
+ 
+ # Tests
+ 
++if(NOT BUILD_STATIC_LIBS)
++  set(BROTLI_DISABLE_TESTS TRUE)
++endif()
++
+ # If we're targeting Windows but not running on Windows, we need Wine
+ # to run the tests...
+ if(NOT BROTLI_DISABLE_TESTS)
+@@ -336,19 +368,19 @@ function(transform_pc_file INPUT_FILE OUTPUT_FILE VERSION)
+   file(WRITE ${OUTPUT_FILE} ${TEXT})
+ endfunction()
+ 
+-transform_pc_file("scripts/libbrotlicommon.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libbrotlicommon.pc" "${BROTLI_VERSION}")
+-
+-transform_pc_file("scripts/libbrotlidec.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libbrotlidec.pc" "${BROTLI_VERSION}")
+-
+-transform_pc_file("scripts/libbrotlienc.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libbrotlienc.pc" "${BROTLI_VERSION}")
+-
+-if(NOT BROTLI_BUNDLED_MODE)
+-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libbrotlicommon.pc"
+-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libbrotlidec.pc"
+-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libbrotlienc.pc"
+-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++if(BUILD_SHARED_LIBS)
++  transform_pc_file("scripts/libbrotlicommon.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libbrotlicommon.pc" "${BROTLI_VERSION}")
++  transform_pc_file("scripts/libbrotlidec.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libbrotlidec.pc" "${BROTLI_VERSION}")
++  transform_pc_file("scripts/libbrotlienc.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libbrotlienc.pc" "${BROTLI_VERSION}")
++
++  if(NOT BROTLI_BUNDLED_MODE)
++    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libbrotlicommon.pc"
++     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libbrotlidec.pc"
++      DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libbrotlienc.pc"
++      DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++  endif()
+ endif()
+ 
+ if (ENABLE_COVERAGE STREQUAL "yes")
+-- 
+2.27.0
+

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,6 +7,7 @@ cmake -GNinja ^
       -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
       -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
       -DCMAKE_BUILD_TYPE:STRING=%CMAKE_CONFIG% ^
+      -DBUILD_STATIC_LIBS=OFF ^
       "%SRC_DIR%"
 if errorlevel 1 exit 1
 ninja

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,7 @@ cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_C_FLAGS=$BROTLI_CFLAGS \
       -GNinja \
       -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_STATIC_LIBS=OFF \
       .
 
 ninja

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,11 @@ source:
   fn: brotli-{{ version }}.tar.gz
   url: https://github.com/google/brotli/archive/v{{ version }}.tar.gz
   sha256: 4c61bfb0faca87219ea587326c467b95acb25555b53d1a421ffa3c8a9296ee2c
+  patches:
+    - 0001-Add-separate-options-to-disable-shared-static-librar.patch
 
 build:
-  number: 1002
-  skip: true  # [win and vc<14]
+  number: 1004
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=brotli
     # No minor versions to ensure ABI compatibility history
@@ -30,23 +31,25 @@ test:
   commands:
     - brotli --help
     - test -f $PREFIX/lib/libbrotlienc$SHLIB_EXT     # [unix]
-    - test -f $PREFIX/lib/libbrotlienc-static.a      # [unix]
     - test -f $PREFIX/lib/libbrotlidec$SHLIB_EXT     # [unix]
-    - test -f $PREFIX/lib/libbrotlidec-static.a      # [unix]
     - test -f $PREFIX/lib/libbrotlicommon$SHLIB_EXT  # [unix]
-    - test -f $PREFIX/lib/libbrotlicommon-static.a   # [unix]
     - test -f $PREFIX/include/brotli/encode.h        # [unix]
     - if not exist %LIBRARY_BIN%\\brotli.exe exit 1               # [win]
     - if not exist %LIBRARY_BIN%\\brotlicommon.dll exit 1         # [win]
     - if not exist %LIBRARY_BIN%\\brotlidec.dll exit 1            # [win]
     - if not exist %LIBRARY_BIN%\\brotlienc.dll exit 1            # [win]
     - if not exist %LIBRARY_LIB%\\brotlicommon.lib exit 1         # [win]
-    - if not exist %LIBRARY_LIB%\\brotlicommon-static.lib exit 1  # [win]
     - if not exist %LIBRARY_LIB%\\brotlidec.lib exit 1            # [win]
-    - if not exist %LIBRARY_LIB%\\brotlidec-static.lib exit 1     # [win]
     - if not exist %LIBRARY_LIB%\\brotlienc.lib exit 1            # [win]
-    - if not exist %LIBRARY_LIB%\\brotlienc-static.lib exit 1     # [win]
     - if not exist %LIBRARY_INC%\\brotli\\encode.h exit 1         # [win]
+
+    # CFEP-18: Static libs shouldn't be part of the main package
+    - test ! -f $PREFIX/lib/libbrotlienc-static.a      # [unix]
+    - test ! -f $PREFIX/lib/libbrotlidec-static.a      # [unix]
+    - test ! -f $PREFIX/lib/libbrotlicommon-static.a   # [unix]
+    - if exist %LIBRARY_LIB%\\brotlicommon-static.lib exit 1  # [win]
+    - if exist %LIBRARY_LIB%\\brotlidec-static.lib exit 1     # [win]
+    - if exist %LIBRARY_LIB%\\brotlienc-static.lib exit 1     # [win]
 
 about:
   home: http://github.com/google/brotli


### PR DESCRIPTION
This removes the static libraries from the main package according to [CFEP-18](https://github.com/conda-forge/cfep/pull/34). This might break some downstream builds but this is intended and we should fix the downstream builds to use the shared libraries before adding an output here.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
